### PR TITLE
Pin protobufjs to version 5.0.1.

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,7 @@
   "description": "JS code to test MALOS-eye (Matrix abstraction layer for OS. Vision component.)",
   "version": "0.0.1",
   "devDependencies": {
-    "protobufjs": "*",
+    "protobufjs": "5.0.1",
     "zmq": "*"
   }
 }


### PR DESCRIPTION
Current examples do not work with version 6X.